### PR TITLE
Abstract AcGuard's user and role handling

### DIFF
--- a/lib/access-control.guard.d.ts
+++ b/lib/access-control.guard.d.ts
@@ -5,5 +5,7 @@ export declare class ACGuard implements CanActivate {
     private readonly reflector;
     private readonly roleBuilder;
     constructor(reflector: Reflector, roleBuilder: RolesBuilder);
-    canActivate(context: ExecutionContext): boolean;
+    getUser(context: ExecutionContext): Promise<any>;
+    getUserRoles(context: ExecutionContext): Promise<any>;
+    canActivate(context: ExecutionContext): Promise<boolean>;
 }

--- a/lib/access-control.guard.js
+++ b/lib/access-control.guard.js
@@ -21,17 +21,24 @@ let ACGuard = class ACGuard {
         this.reflector = reflector;
         this.roleBuilder = roleBuilder;
     }
-    canActivate(context) {
+    async getUser(context) {
+        const request = context.switchToHttp().getRequest();
+        return request.user;
+    }
+    async getUserRoles(context) {
+        const user = await this.getUser(context);
+        if (!user)
+            throw new common_1.UnauthorizedException();
+        return user.roles;
+    }
+    async canActivate(context) {
         const roles = this.reflector.get('roles', context.getHandler());
         if (!roles) {
             return true;
         }
-        const request = context.switchToHttp().getRequest();
-        const user = request.user;
-        if (!user)
-            throw new common_1.UnauthorizedException();
+        const userRoles = await this.getUserRoles(context);
         const hasRoles = roles.every(role => {
-            role.role = user.roles;
+            role.role = userRoles;
             const permission = this.roleBuilder.permission(role);
             return permission.granted;
         });

--- a/src/access-control.guard.ts
+++ b/src/access-control.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { IQueryInfo } from 'accesscontrol';
 import { Role } from './role.interface';
 import { InjectRolesBuilder } from './decorators/inject-roles-builder.decorator';
 import { RolesBuilder } from './roles-builder.class';
@@ -30,8 +31,9 @@ export class ACGuard<User extends any = any> implements CanActivate {
     
     const userRoles = await this.getUserRoles(context);
     const hasRoles = roles.every(role => {
-      (role as any).role = userRoles;
-      const permission = this.roleBuilder.permission(role);
+      const queryInfo: IQueryInfo = role;
+      queryInfo.role = userRoles;
+      const permission = this.roleBuilder.permission(queryInfo);
       return permission.granted;
     });
     return hasRoles;

--- a/src/access-control.guard.ts
+++ b/src/access-control.guard.ts
@@ -11,16 +11,26 @@ export class ACGuard implements CanActivate {
     @InjectRolesBuilder() private readonly roleBuilder: RolesBuilder,
   ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async getUser(context: ExecutionContext): Promise<any> {
+    const request = context.switchToHttp().getRequest();
+    return request.user;
+  }
+
+  async getUserRoles(context: ExecutionContext): Promise<any> {
+    const user = await this.getUser(context);
+    if (!user) throw new UnauthorizedException();
+    return user.roles
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const roles = this.reflector.get<Role[]>('roles', context.getHandler());
     if (!roles) {
       return true;
     }
-    const request = context.switchToHttp().getRequest();
-    const user = request.user;
-    if (!user) throw new UnauthorizedException();
+    
+    const userRoles = await this.getUserRoles(context);
     const hasRoles = roles.every(role => {
-      (role as any).role = user.roles;
+      (role as any).role = userRoles;
       const permission = this.roleBuilder.permission(role);
       return permission.granted;
     });

--- a/src/access-control.guard.ts
+++ b/src/access-control.guard.ts
@@ -5,18 +5,18 @@ import { InjectRolesBuilder } from './decorators/inject-roles-builder.decorator'
 import { RolesBuilder } from './roles-builder.class';
 
 @Injectable()
-export class ACGuard implements CanActivate {
+export class ACGuard<User extends any = any> implements CanActivate {
   constructor(
     private readonly reflector: Reflector,
     @InjectRolesBuilder() private readonly roleBuilder: RolesBuilder,
   ) {}
 
-  async getUser(context: ExecutionContext): Promise<any> {
+  async getUser(context: ExecutionContext): Promise<User> {
     const request = context.switchToHttp().getRequest();
     return request.user;
   }
 
-  async getUserRoles(context: ExecutionContext): Promise<any> {
+  async getUserRoles(context: ExecutionContext): Promise<string | string[]> {
     const user = await this.getUser(context);
     if (!user) throw new UnauthorizedException();
     return user.roles


### PR DESCRIPTION
Overriding getUser can be used to support other non-http contexts or be used to get a user from somewhere other than `req.user`.

Overriding getUserRoles can be used to get roles from another prop, rename roles, add implicit roles, or replace the UnauthorizedException behaviour when no user is present.