### PR TITLE
Export ROLES_BUILDER_TOKEN

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './access-control.module';
 export * from './roles-builder.class';
 export * from './role.interface';
 export * from './access-control.guard';
+export { ROLES_BUILDER_TOKEN } from './constants'


### PR DESCRIPTION
This allows RoleBuilder to be injected into factory providers without referencing the constants file.