### PR TITLE
Make getUser and getUserRoles protected

### DIFF
--- a/lib/access-control.guard.d.ts
+++ b/lib/access-control.guard.d.ts
@@ -5,7 +5,7 @@ export declare class ACGuard<User extends any = any> implements CanActivate {
     private readonly reflector;
     private readonly roleBuilder;
     constructor(reflector: Reflector, roleBuilder: RolesBuilder);
-    private getUser;
-    private getUserRoles;
+    protected getUser(context: ExecutionContext): Promise<User>;
+    protected getUserRoles(context: ExecutionContext): Promise<string | string[]>;
     canActivate(context: ExecutionContext): Promise<boolean>;
 }

--- a/src/access-control.guard.ts
+++ b/src/access-control.guard.ts
@@ -12,12 +12,12 @@ export class ACGuard<User extends any = any> implements CanActivate {
     @InjectRolesBuilder() private readonly roleBuilder: RolesBuilder,
   ) {}
 
-  private async getUser(context: ExecutionContext): Promise<User> {
+  protected async getUser(context: ExecutionContext): Promise<User> {
     const request = context.switchToHttp().getRequest();
     return request.user;
   }
 
-  private async getUserRoles(context: ExecutionContext): Promise<string | string[]> {
+  protected async getUserRoles(context: ExecutionContext): Promise<string | string[]> {
     const user = await this.getUser(context);
     if (!user) throw new UnauthorizedException();
     return user.roles;


### PR DESCRIPTION
These methods were intended to allow subclasses to override them. However they cannot be overridden if they are private.